### PR TITLE
Support for multiple TXT records

### DIFF
--- a/vimexx-dns.in
+++ b/vimexx-dns.in
@@ -33,6 +33,7 @@ my $config = AppConfig::Std->new( { ERROR => sub { printf STDERR "Ignoring inval
 
 # These are all the options that can be set in a config file or as an argument
 $config->define("record_ttl|t=s",   { DEFAULT => '24h', VALIDATE => '^(24h|8h|4h|2h|1h|10m|5m)$' });
+$config->define("add|a!",           { DEFAULT => 0 });
 $config->define("delete|d!",        { DEFAULT => 0 });
 $config->define("dryrun!",          { DEFAULT => 0 });
 $config->define("clear|c!",         { DEFAULT => 0 });
@@ -75,6 +76,8 @@ vimexx-dns [OPTION]... DOMAIN [CONTENT]
   -n,-nons           Do NOT use an authorative nameserver to find the actual TTL
                      of a DNS record. When this is set, all records will be set to
                      the TTL specified with -t.
+
+  -a,-add            Forces an ADD dns record in stead of Update when records already exists
 
   -d,-delete         Deletes the most recently added record, but only if
                      it was added in the last 600 seconds.
@@ -355,6 +358,13 @@ foreach my $record ( @{$records} ) {
       # Nothing actually changed, just keep this record
       printf("Unchanged DNS '%s' record '%s' -> '%s'\n", $record->{'type'}, $record->{'name'}, $new_record{'content'}) if $config->verbose;
       push @{$data{'body'}{'dns_records'}} , $record;
+
+    } elsif ( $config->add ) {
+
+      # Force ADD even when record exists
+      printf("Keep DNS '%s' record '%s' -> '%s'\n", $record->{'type'}, $record->{'name'}, $record->{'content'}) unless $config->quiet;
+      push @{$data{'body'}{'dns_records'}} , $record;
+      $found_old = 0;
 
     } else {
 

--- a/vimexx-dns.in
+++ b/vimexx-dns.in
@@ -379,9 +379,13 @@ foreach my $record ( @{$records} ) {
 
 # Finally, if the new_record was in fact totally new, add it here
 unless ( $found_old ) {
-  printf("Adding DNS '%s' record '%s' -> '%s'\n", $new_record{'type'}, $new_record{'name'}, $new_record{'content'}) unless $config->quiet;
-  push @{$data{'body'}{'dns_records'}} , \%new_record;
-  $dns_changed = 1;
+  if ( $config->delete ) {
+    printf("Record to Delete does't exists DNS '%s' record '%s'\n", $new_record{'type'}, $new_record{'name'}) unless $config->quiet;
+  } else {
+    printf("Adding DNS '%s' record '%s' -> '%s'\n", $new_record{'type'}, $new_record{'name'}, $new_record{'content'}) unless $config->quiet;
+    push @{$data{'body'}{'dns_records'}} , \%new_record;
+    $dns_changed = 1;
+  }
 }
 
 if ( $dump_loaded ) {


### PR DESCRIPTION
- Added test to avoid trying to ADD and DNS records for a "-d" task when the record doesn't exists.
- Added "-a"/"-add" parameter to allow to add multiple DNS records with the same name.
   When "-a" is provided it will skip trying to Update the existing record.

This is a fix for this scenario for a certificate that is used for root domain and all subdomains:

```
  "identifiers": [
    {
      "type": "dns",
      "value": "*.mydomain.nl"
    },
    {
      "type": "dns",
      "value": "mydomain.nl"
    }
  ],
```

certbot will run authenticate.sh & cleanup.sh for each DNS-1 definitions.
This means it would add the TXT and then Update the TXT record, making the certbot fail:

```
2025-06-29 04:07:13,744:INFO:certbot.hooks:Output from authenticator.sh:
Adding DNS 'TXT' record '_acme-challenge.mydomain.nl.' -> 'RZQkm2YH8pJHOS......................................'

2025-06-29 04:07:32,309:INFO:certbot.hooks:Output from authenticator.sh:
Updating DNS 'TXT' record '_acme-challenge.mydomain.nl.' -> 'KWDT_1j96Ij_oTib....................................'
```
The Failure in letsencrypt.log:
`
Detail: Incorrect TXT record "KWDT_1j96Ij_oTib...................................." found at _acme-challenge.mydomain.nl
`

Then at Cleanup it would trigger an error the second run:
```
2025-06-29 04:07:39,407:INFO:certbot.hooks:Output from cleanup.sh:
Deleting DNS 'TXT' record '_acme-challenge.mydomain.nl.'

2025-06-29 04:07:42,598:INFO:certbot.hooks:Output from cleanup.sh:
Adding DNS 'TXT' record '_acme-challenge.mydomain.nl.' -> ''

2025-06-29 04:07:42,600:ERROR:certbot.hooks:Error output from cleanup.sh:
Use of uninitialized value $new_record{"content"} in printf at /usr/local/bin/vimexx-dns line 393.

```